### PR TITLE
Use `sln_det` instead of basic determinant

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -87,16 +87,6 @@ pub fn sln_det(m: &Array2<f64>) -> Result<(f64, f64)> {
     })
 }
 
-/// Compute determinant of a square matrix using LAPACK.
-///
-/// For ICA objectives that need log|det|, prefer using `sln_det` directly
-/// to avoid numerical issues with very large or small determinants.
-pub fn determinant(m: &Array2<f64>) -> Result<f64> {
-    m.det().map_err(|e| PicardError::ComputationError {
-        message: format!("LU decomposition failed in determinant computation: {}", e),
-    })
-}
-
 /// Make a matrix skew-symmetric: A <- (A - A^T) / 2
 pub fn skew_symmetric(a: &Array2<f64>) -> Array2<f64> {
     (a - &a.t()) / 2.0
@@ -131,13 +121,6 @@ mod tests {
                 assert!((exp_zero[[i, j]] - expected).abs() < 1e-10);
             }
         }
-    }
-
-    #[test]
-    fn test_determinant() {
-        let m = array![[1.0, 2.0], [3.0, 4.0]];
-        let det = determinant(&m).unwrap();
-        assert!((det - (-2.0)).abs() < 1e-10);
     }
 
     #[test]

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -163,7 +163,7 @@ impl Picard {
             config.ls_tries,
             config.verbose,
             covariance.as_ref(),
-        );
+        )?;
 
         // Combine transformations
         let w = w.dot(&w_init);


### PR DESCRIPTION
Better numerics, better gradients, … = faster convergence?

- Docs https://docs.rs/ndarray-linalg/latest/ndarray_linalg/solve/trait.Determinant.html

(No faster convergence :-1:)

Benchmark vs Python picard in lmmx/arxiv_explorer repo shows it's still faster but more iterations
(unchanged n_iter):

```
(arxiv_explorer) louis 🌟 ~/dev/arxiv_explorer $ qp benchmark_topics.py 
Loading 1000 documents...

============================================================
POLARS-FASTEMBED S³ (raw 384D)
============================================================
Picard converged: true, n_iter: 39, final_grad: 7.1879e-5
Time: 0.165s

============================================================
PICARD (raw 384D, Python)
============================================================
Picard: 0.173s
Iterations: 33

============================================================
PCA (100D) + POLARS-FASTEMBED S³
============================================================
PCA: 0.347s (explained variance: 75.0%)
Picard converged: true, n_iter: 29, final_grad: 6.2891e-5
S³: 0.039s
Total: 0.386s

============================================================
PCA + PICARD (Python)
============================================================
PCA: 0.419s
Picard: 0.109s
Iterations: 42
Total: 0.528s

============================================================
SUMMARY
============================================================
polars-fastembed raw 384D:     0.165s
Picard raw 384D (Python):     0.173s
PCA 100D + polars-fastembed: 0.386s
PCA 100D + Picard:           0.528s
```
